### PR TITLE
Add beforeDeserialize and afterSerialize hooks for arbitrary manipulation

### DIFF
--- a/form-persistence.js
+++ b/form-persistence.js
@@ -179,6 +179,9 @@ const FormPersistence = (function () {
         }
         let config = Object.assign({}, defaults, options)
         let data = serialize(form, config)
+        if(options.afterSerialize) {
+          data = options.afterSerialize(form, data)
+        }
         let storage = config.useSessionStorage ? sessionStorage : localStorage
         storage.setItem(getStorageKey(form, config.uuid), JSON.stringify(data))
     }
@@ -206,6 +209,9 @@ const FormPersistence = (function () {
             excludeFilter: null
         }
         let config = Object.assign({}, defaults, options)
+        if(options.beforeDeserialize) {
+          data = options.beforeDeserialize(form, data)
+        }
         // apply given value functions first
         let speciallyHandled = []
         if (config.valueFunctions !== null) {

--- a/form-persistence.js
+++ b/form-persistence.js
@@ -370,12 +370,4 @@ const FormPersistence = (function () {
     }
 })();
 
-/**
- * Export the module if applicable.
- */
-(function () {
-    // istanbul ignore else
-    if (typeof module !== 'undefined' && module.exports) {
-        module.exports = exports = FormPersistence
-    }
-})();
+export default FormPersistence


### PR DESCRIPTION
Hello! It looks like this may no longer be maintained. But if it is, and this PR looks good, I can make a documentation and testing pass.

Anyways, this PR enables performing arbitrary transformations during serialization/deserialization that are not possible with the current hooks. For example, if the name attributes aren't known in advance, or integrating custom form elements. Both of which are true for my specific use-case.

Let me know if there's interest in eventually merging something like this!